### PR TITLE
add new filter when an email notification is sent.

### DIFF
--- a/includes/class-fep-emails.php
+++ b/includes/class-fep-emails.php
@@ -91,7 +91,7 @@ class Fep_Emails
 			
 			
 			fep_add_email_filters();
-			
+			apply_filters('fep_notification_event', $postid, $post);
 			foreach( $participants as $participant ) 
 			{
 				if( $participant == $post->post_author )


### PR DESCRIPTION
Hey Shamim,

I'd super love if you could add this filter. Basically, I'm creating a text message notification that occurs when a new message happens, and for that I need the data from $post. So if this filter existed in the send_email function, I could do it super easily. Right now I've manually added the filter to the plugin, but then I won't be able to automatically update the plugin when you make changes. 

- Aurooba
