### PR TITLE
Set user lookup limit to 100

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -31,7 +31,7 @@ jQuery( document ).ready( function( $ ) {
 				if ( $.isEmptyObject( response ) ) {
 					$( '#fep-result ul' ).append('<li>' + fep_script.no_match + '</li>');
 				} else {
-					$.each( response.slice(0,5), function(i, v) {
+					$.each( response, function(i, v) {
 						$( '#fep-result ul' ).append('<li><a href="#" data-user_nicename="' + v.nicename + '" data-user_name="' + v.name + '">' + v.name + '</a></li>');
 					});
 				}

--- a/includes/class-fep-rest-api.php
+++ b/includes/class-fep-rest-api.php
@@ -211,7 +211,7 @@ class FEP_REST_API {
 			'search'         => "*{$q}*",
 			'search_columns' => array( 'user_login', 'display_name' ),
 			'exclude'        => $exclude,
-			'number'         => 10,
+			'number'         => 100,
 			'orderby'        => 'display_name',
 			'order'          => 'ASC',
 			'role__in'       => fep_get_option( 'userrole_access', array() ),


### PR DESCRIPTION
The default user lookup limit is set to 5 which is too restrictive for site with a significant user base size.